### PR TITLE
Update runwith.py

### DIFF
--- a/runwith.py
+++ b/runwith.py
@@ -4,6 +4,8 @@
 # in order to ensure that stdin and stdout are opened in binary, rather
 # than text, mode.
 
+# encoding=utf8
+
 import sys, json, struct, os
 import subprocess
 


### PR DESCRIPTION
Hello Waldner, I am Massimo,
the added line prevents, on some machines, the error:
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2
I see it is related to the encodings enabled in the machine.
Thank you.
Bye.